### PR TITLE
Fix Issue #139

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,14 +36,13 @@ dependencies {
         exclude group: 'com.android.support', module: 'design'
     }
 
-    implementation 'org.apache.directory.studio:org.apache.commons.io:2.4'
+    implementation group: 'commons-io', name: 'commons-io', version: '2.5'
     implementation 'com.android.support:cardview-v7:26.1.0'
     implementation 'com.android.support:recyclerview-v7:26.1.0'
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support:design:26.1.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.0'
     implementation 'com.android.support:support-v4:26.1.0'
-    implementation 'org.apache.directory.studio:org.apache.commons.io:2.4'
     testImplementation 'junit:junit:4.12'
     implementation 'com.jakewharton:butterknife:8.8.1'
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'


### PR DESCRIPTION
### Description

Fixes #139 
The original build.gradle file had a dependency on apache commons library, that caused the error: INSTALL_FAILED_NO_MATCHING_ABIS on devices running Oreo and above.
Referencing the Stackoverflow answer [here](https://stackoverflow.com/questions/46094281/install-failed-no-matching-abis-error-on-android-8), I have updated the build.gradle file to fix this issue.

Tested on Google Pixel running Android Pie 9.0.

### Type of Change:


- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)




### How Has This Been Tested?
The application was tested on a Google Pixel running Android 9.0 Pie.


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes
